### PR TITLE
Updated links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ For a live, detailed example, see in `PFAboutWindowExample` directory.
    ```
 
 # Acknowledgments
-Thanks to [**@DangerCove**](github.com/dangercove) for its DCOAboutWindow, which served as a ground for this (heavy) modification. Thanks !
+Thanks to [**@DangerCove**](https://github.com/dangercove) for its DCOAboutWindow, which served as a ground for this (heavy) modification. Thanks !
 
 # License (MIT)
 The MIT License (MIT)
 
-Copyright (c) 2015 Perceval [**@perfaram**](github.com/perfaram) FARAMAZ
+Copyright (c) 2015 Perceval [**@perfaram**](https://github.com/perfaram) FARAMAZ
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Without the ‘https://' the links would return GitHub’s 404 page.
Therefore, I added the ‘https://' part.
