### PR TITLE
Add cocoapods support

### DIFF
--- a/PFAboutWindow.podspec
+++ b/PFAboutWindow.podspec
@@ -1,0 +1,42 @@
+Pod::Spec.new do |s|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  s.name         = "PFAboutWindow"
+  s.version      = "1.0.0"
+  s.summary      = "A replacement for the 'About' dialog."
+
+  s.description  = <<-DESC
+                   A sleek replacement for the otherwise bleak 'About' dialog.
+                   Its nice, looks like xCode6's one, and offers the following abilities
+
+                   * Open the app's website by clicking its (big) icon (in the dialog) (see Usage below)
+                   * Extend the dialog to show the 'License Agreement', or
+                   * The 'Acknowledgments' (see Content below)
+                   * Translate the button's text (see Localization below)
+                   DESC
+
+  s.homepage     = "https://github.com/perfaram/PFAboutWindow"
+  s.screenshots  = "https://raw.githubusercontent.com/perfaram/PFAboutWindow/master/screenshots/PFAboutWindow.gif"
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  s.license      = "MIT"
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  s.author             = "Perceval FARAMAZ"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  s.osx.deployment_target = "10.9"
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  s.source       = { :git => "https://github.com/perfaram/PFAboutWindow.git" }
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  s.source_files  = "PFAboutWindow/**/*.{h,m,xib}"
+
+  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+end

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ A sleek replacement for the otherwise bleak "About" dialog. Its nice, looks like
 
 Clone this repo and add files from `PFAboutWindow` to your project.
 
+## Using [cocoapods](http://cocoapods.org/)
+
+Add `pod 'PFAboutWindow', :git => 'https://github.com/perfaram/PFAboutWindow.git'` to your `Podfile` and run `pod install`.
+Add `use_frameworks!` to the end of the `Podfile`.
+
 # Usage
 
 For a live, detailed example, see in `PFAboutWindowExample` directory.


### PR DESCRIPTION
Just add the podspec file and add section in readme
https://cocoapods.org/
http://nshipster.com/cocoapods/

then you can publish your project but not mandatory
http://guides.cocoapods.org/making/getting-setup-with-trunk
the user will put only : pod 'PFAboutWindow' (no more git specification)
